### PR TITLE
option to also count files with \include

### DIFF
--- a/tpbuild-scripts/texcount.tpbuild
+++ b/tpbuild-scripts/texcount.tpbuild
@@ -1,2 +1,2 @@
 #!/bin/bash
-texcount $TEXPAD_ROOTFILE_NO_EXT.tex
+texcount $TEXPAD_ROOTFILE_NO_EXT.tex -merge


### PR DESCRIPTION
using -merge on texcount does a recursive count to also include files included with \include or \input
